### PR TITLE
Use Dataset factory in client

### DIFF
--- a/hoard/client.py
+++ b/hoard/client.py
@@ -1,9 +1,9 @@
-from typing import Tuple
+from typing import Any, Callable, Tuple
 
 import requests
 
 from hoard.api import Api
-from hoard.models import create_from_dict, Dataset
+from hoard.models import Dataset
 
 
 class Transport:
@@ -27,9 +27,12 @@ class DataverseKey:
 
 
 class Client:
-    def __init__(self, api: Api, transport: Transport) -> None:
+    def __init__(
+        self, api: Api, transport: Transport, factory: Callable[[Any], Dataset]
+    ) -> None:
         self.api = api
         self.transport = transport
+        self.factory = factory
 
     def get(self, *, pid: str = None, id: int = None) -> Dataset:
         if pid is not None:
@@ -39,7 +42,7 @@ class Client:
         else:
             raise Exception("You must supply either an id or a pid")
         resp = self.transport.send(req)
-        return create_from_dict(resp.json())
+        return self.factory(resp.json())
 
     def create(self, dataset: Dataset, parent: str = "root") -> Tuple[int, str]:
         req = self.api.create_dataset(parent, dataset.asdict())

--- a/hoard/models.py
+++ b/hoard/models.py
@@ -9,8 +9,12 @@ class Dataset:
         return attr.asdict(self)
 
 
-def create_from_dict(data: dict) -> Dataset:
-    title = data["data"]["latestVersion"]["metadataBlocks"]["citation"]["fields"][0][
+def create_whoas(item):
+    return Dataset(...)
+
+
+def create_rdr(item: dict) -> Dataset:
+    title = item["data"]["latestVersion"]["metadataBlocks"]["citation"]["fields"][0][
         "value"
     ]
     return Dataset(title=title)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ import requests_mock
 
 from hoard.api import Api
 from hoard.client import Client, Transport, DataverseKey
-from hoard.models import Dataset
+from hoard.models import Dataset, create_rdr
 
 
 @pytest.fixture
@@ -25,7 +25,7 @@ def response():
 def test_client_gets_dataset_by_id(response):
     with requests_mock.Mocker() as m:
         m.get("http+mock://example.com/api/v1/datasets/666", json=response)
-        client = Client(Api("http+mock://example.com"), Transport())
+        client = Client(Api("http+mock://example.com"), Transport(), create_rdr)
         dv = client.get(id=666)
         assert dv.title == "The Hoard"
 
@@ -37,7 +37,7 @@ def test_client_gets_dataset_by_pid(response):
             "?persistentId=doi:foo/bar",
             json=response,
         )
-        client = Client(Api("http+mock://example.com"), Transport())
+        client = Client(Api("http+mock://example.com"), Transport(), create_rdr)
         dv = client.get(pid="doi:foo/bar")
         assert dv.title == "The Hoard"
 
@@ -49,7 +49,7 @@ def test_client_creates_dataset():
             "http+mock://example.com/api/v1/root/datasets",
             json={"data": {"id": 1, "persistentId": "set1"}},
         )
-        client = Client(Api("http+mock://example.com/"), Transport())
+        client = Client(Api("http+mock://example.com/"), Transport(), create_rdr)
         dv_id, p_id = client.create(record)
     assert m.last_request.json() == record.asdict()
     assert dv_id == 1
@@ -63,6 +63,6 @@ def test_client_adds_authentication():
             json={"data": {"id": 1, "persistentId": "set1"}},
         )
         api = Api("http+mock://example.com", DataverseKey("123"))
-        client = Client(api, Transport())
+        client = Client(api, Transport(), create_rdr)
         client.create(Dataset(title="whatever"))
     assert m.last_request.headers["X-Dataverse-key"] == "123"


### PR DESCRIPTION
It seems likely we are going to be pulling multiple sources from the
same repository. This may be true for both DSpace and Dataverse (and
maybe others). We'll also likely need to be able to handle the mapping
from the source to our data model differently for each dataset. The
client shouldn't be tied to the source, but rather to the underlying
repository.

This shifts specific decisions about how to create a dataset outside of
the client so that a Dataverse client, for example, can be used to
harvest multiple datasets.