### PR TITLE
Add source stubs

### DIFF
--- a/hoard/client.py
+++ b/hoard/client.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import requests
 
 from hoard.api import Api
-from hoard.models import create_from_dict, Dataset
+from hoard.models import Dataset
 
 
 class Transport:
@@ -26,12 +26,12 @@ class DataverseKey:
         return req
 
 
-class Client:
+class DataverseClient:
     def __init__(self, api: Api, transport: Transport) -> None:
         self.api = api
         self.transport = transport
 
-    def get(self, *, pid: str = None, id: int = None) -> Dataset:
+    def get(self, *, pid: str = None, id: int = None) -> dict:
         if pid is not None:
             req = self.api.get_dataset_by_pid(pid)
         elif id is not None:
@@ -39,10 +39,14 @@ class Client:
         else:
             raise Exception("You must supply either an id or a pid")
         resp = self.transport.send(req)
-        return create_from_dict(resp.json()["data"])
+        return resp.json()
 
     def create(self, dataset: Dataset, parent: str = "root") -> Tuple[int, str]:
         req = self.api.create_dataset(parent, dataset.asdict())
         resp = self.transport.send(req)
         data = resp.json()["data"]
         return data["id"], data["persistentId"]
+
+
+class DSpaceClient:
+    ...

--- a/hoard/source.py
+++ b/hoard/source.py
@@ -1,0 +1,37 @@
+from typing import Iterator
+
+from hoard.client import DataverseClient, DSpaceClient
+from hoard.models import Dataset
+
+
+class JPAL:
+    def __init__(self, client: DataverseClient) -> None:
+        self.client = client
+
+    def __iter__(self) -> Iterator[Dataset]:
+        return self
+
+    def __next__(self) -> Dataset:
+        ...
+
+
+class RDR:
+    def __init__(self, client: DataverseClient) -> None:
+        self.client = client
+
+    def __iter__(self) -> Iterator[Dataset]:
+        return self
+
+    def __next__(self) -> Dataset:
+        ...
+
+
+class WHOAS:
+    def __init__(self, client: DSpaceClient) -> None:
+        self.client = client
+
+    def __iter__(self) -> Iterator[Dataset]:
+        return self
+
+    def __next__(self) -> Dataset:
+        ...

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@ import pytest
 import requests_mock
 
 from hoard.api import Api
-from hoard.client import Client, Transport, DataverseKey
+from hoard.client import DataverseClient, Transport, DataverseKey
 from hoard.models import create_from_dict
 
 
@@ -31,9 +31,9 @@ def dataset(response):
 def test_client_gets_dataset_by_id(response):
     with requests_mock.Mocker() as m:
         m.get("http+mock://example.com/api/v1/datasets/666", json=response)
-        client = Client(Api("http+mock://example.com"), Transport())
+        client = DataverseClient(Api("http+mock://example.com"), Transport())
         dv = client.get(id=666)
-        assert dv.title == "The Hoard"
+        assert dv == response
 
 
 def test_client_gets_dataset_by_pid(response):
@@ -43,9 +43,9 @@ def test_client_gets_dataset_by_pid(response):
             "?persistentId=doi:foo/bar",
             json=response,
         )
-        client = Client(Api("http+mock://example.com"), Transport())
+        client = DataverseClient(Api("http+mock://example.com"), Transport())
         dv = client.get(pid="doi:foo/bar")
-        assert dv.title == "The Hoard"
+        assert dv == response
 
 
 def test_client_creates_dataset(dataset):
@@ -54,7 +54,7 @@ def test_client_creates_dataset(dataset):
             "http+mock://example.com/api/v1/root/datasets",
             json={"data": {"id": 1, "persistentId": "set1"}},
         )
-        client = Client(Api("http+mock://example.com/"), Transport())
+        client = DataverseClient(Api("http+mock://example.com/"), Transport())
         dv_id, p_id = client.create(dataset)
     assert m.last_request.json() == dataset.asdict()
     assert dv_id == 1
@@ -68,6 +68,6 @@ def test_client_adds_authentication(dataset):
             json={"data": {"id": 1, "persistentId": "set1"}},
         )
         api = Api("http+mock://example.com", DataverseKey("123"))
-        client = Client(api, Transport())
+        client = DataverseClient(api, Transport())
         client.create(dataset)
     assert m.last_request.headers["X-Dataverse-key"] == "123"


### PR DESCRIPTION
This stubs out a set of source objects whose job is to produce a stream
of Datasets. It also makes the clients a bit lower level so that they
aren't concerned at all with creating Datasets objects.