### PR TITLE
Add datasets from JPAL source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Mac
+.DS_Store

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ flake8-bugbear = "*"
 click = "*"
 requests = "*"
 attrs = "*"
+bs4 = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6f68c7d672c89d5fd5a4c29eb5d463dcfc358af0315bf59e3118d590cdd89eb4"
+            "sha256": "334fb331e8f1fe64e6105579cc255b7689f506d870808977873fb158f39c62bf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,21 @@
             ],
             "index": "pypi",
             "version": "==19.3.0"
+        },
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:73cc4d115b96f79c7d77c1c7f7a0a8d4c57860d1041df407dd1aae7f07a77fd7",
+                "sha256:a6237df3c32ccfaee4fd201c8f5f9d9df619b93121d01353a64a73ce8c6ef9a8",
+                "sha256:e718f2342e2e099b640a34ab782407b7b676f47ee272d6739e60b8ea23829f2c"
+            ],
+            "version": "==4.9.1"
+        },
+        "bs4": {
+            "hashes": [
+                "sha256:36ecea1fd7cc5c0c6e4a1ff075df26d50da647b75376626cc186e2212886dd3a"
+            ],
+            "index": "pypi",
+            "version": "==0.0.1"
         },
         "certifi": {
             "hashes": [
@@ -51,7 +66,6 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "requests": {
@@ -62,12 +76,18 @@
             "index": "pypi",
             "version": "==2.24.0"
         },
+        "soupsieve": {
+            "hashes": [
+                "sha256:1634eea42ab371d3d346309b93df7870a88610f0725d47528be902a0d95ecc55",
+                "sha256:a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232"
+            ],
+            "version": "==2.0.1"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.10"
         }
     },
@@ -154,7 +174,6 @@
                 "sha256:ce7866f29d3025b5b34c2e944e66ebef0d92e4a4f2463f7266daa03a1332a651",
                 "sha256:e26c993bd4b220429d4ec8c1468eca445a4064a61c74ca08da7429af9bc53bb0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==5.2.1"
         },
         "coveralls": {
@@ -192,7 +211,6 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "mccabe": {
@@ -207,7 +225,6 @@
                 "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5",
                 "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==8.4.0"
         },
         "mypy": {
@@ -242,7 +259,6 @@
                 "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
                 "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.4"
         },
         "pathspec": {
@@ -257,7 +273,6 @@
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "py": {
@@ -265,7 +280,6 @@
                 "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
                 "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.9.0"
         },
         "pycodestyle": {
@@ -273,7 +287,6 @@
                 "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
                 "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.6.0"
         },
         "pyflakes": {
@@ -281,7 +294,6 @@
                 "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
         },
         "pyparsing": {
@@ -289,7 +301,6 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -355,7 +366,6 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "toml": {
@@ -404,7 +414,6 @@
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.10"
         },
         "wcwidth": {

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,39 @@
+import json
+
+import pytest
+
+from hoard.models import Author, Contact, Dataset, Description
+
+
+@pytest.fixture
+def dataset():
+    author = Author(authorName="Finch, Fiona", authorAffiliation="Birds Inc.")
+    contact = Contact(
+        datasetContactName="Finch, Fiona", datasetContactEmail="finch@mailinator.com"
+    )
+    description = Description(
+        dsDescriptionValue="Darwin's finches (also known"
+        " as the Galápagos finches) are a group of about"
+        " fifteen species of passerine birds."
+    )
+    dataset = Dataset(
+        authors=[author],
+        contacts=[contact],
+        description=[description],
+        subjects=["Medicine, Health and Life Sciences"],
+        title="Darwin's Finches",
+    )
+    return dataset
+
+
+@pytest.fixture
+def dataverse_json_record():
+    with open("fixtures/dataset-finch1.json") as f:
+        r = json.load(f)
+        return r
+
+
+@pytest.fixture
+def dataverse_oai_xml_records():
+    records = ['<record><header><identifier>12345</identifier><datestamp>2020-01-01T01:01:11Z</datestamp><setSpec>cool_research_lab</setSpec></header><metadata directApiCall="http+mock://example.com/api/datasets/export?exporter=dataverse_json&persistentId=12345"/></record>']
+    return records

--- a/hoard/client.py
+++ b/hoard/client.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Iterator, Tuple
 
 import requests
 
@@ -55,3 +55,9 @@ class DSpaceClient:
 class OAIClient:
     def __init__(self, url):
         self.url = url
+
+    def __iter__(self) -> Iterator[str]:
+        return self
+
+    def __next__(self) -> str:
+        ...

--- a/hoard/models.py
+++ b/hoard/models.py
@@ -73,25 +73,63 @@ class Dataset:
         return result
 
 
-def create_from_dict(data: dict) -> Dataset:
-    title = data["title"]
-    author = Author(
-        authorName=data["authorName"], authorAffiliation=data["authorAffiliation"]
-    )
-    contact = Contact(
-        datasetContactName=data["contactName"], datasetContactEmail=data["contactEmail"]
-    )
-    description = Description(dsDescriptionValue=data["description"])
+# Helper functions
+
+
+def create_from_dataverse_json(data: dict) -> Dataset:
+    fields = data["datasetVersion"]["metadataBlocks"]["citation"]["fields"]
+    title = [x["value"] for x in fields if x["typeName"] == "title"][0]
+    authors = [get_authors(x["value"]) for x in fields if x["typeName"] == "author"][0]
+    contacts = [
+        get_contacts(x["value"]) for x in fields if x["typeName"] == "datasetContact"
+    ][0]
+    description = [
+        get_descriptions(x["value"]) for x in fields if x["typeName"] == "dsDescription"
+    ][0]
+    subjects = [[v for v in x["value"]] for x in fields if x["typeName"] == "subject"][
+        0
+    ]
+
     return Dataset(
         title=title,
-        authors=[author],
-        contacts=[contact],
-        description=[description],
-        subjects=data["subjects"],
+        authors=authors,
+        contacts=contacts,
+        description=description,
+        subjects=subjects,
     )
 
 
-# Metadata block types
+def get_authors(values: dict) -> List[Author]:
+    authors = []
+    for v in values:
+        author = Author(
+            authorName=v["authorName"]["value"],
+            authorAffiliation=v["authorAffiliation"]["value"],
+        )
+        authors.append(author)
+    return authors
+
+
+def get_contacts(values: dict) -> List[Contact]:
+    contacts = []
+    for v in values:
+        contact = Contact(
+            datasetContactName=v["datasetContactName"]["value"],
+            datasetContactEmail=v["datasetContactEmail"]["value"],
+        )
+        contacts.append(contact)
+    return contacts
+
+
+def get_descriptions(values: dict) -> List[Description]:
+    descriptions = []
+    for v in values:
+        description = Description(dsDescriptionValue=v["dsDescriptionValue"]["value"],)
+        descriptions.append(description)
+    return descriptions
+
+
+# Dataverse metadata block types
 
 
 def compound(values: List, type_name: str, subtype_names: List[str]) -> dict:

--- a/hoard/source.py
+++ b/hoard/source.py
@@ -1,7 +1,10 @@
+from bs4 import BeautifulSoup  # type: ignore
+import requests
 from typing import Iterator
 
+
 from hoard.client import DataverseClient, DSpaceClient, OAIClient
-from hoard.models import Dataset
+from hoard.models import create_from_dataverse_json, Dataset
 
 
 class JPAL:
@@ -12,7 +15,12 @@ class JPAL:
         return self
 
     def __next__(self) -> Dataset:
-        ...
+        record = next(self.client)
+        xml = BeautifulSoup(record, "html.parser")
+        json_url = xml.metadata["directapicall"]
+        dataverse_json = requests.get(json_url).json()
+        dataset = create_from_dataverse_json(dataverse_json)
+        return dataset
 
 
 class RDR:

--- a/hoard/source.py
+++ b/hoard/source.py
@@ -10,6 +10,7 @@ from hoard.models import create_from_dataverse_json, Dataset
 class JPAL:
     def __init__(self, client: OAIClient) -> None:
         self.client = client
+        self.session = requests.Session()
 
     def __iter__(self) -> Iterator[Dataset]:
         return self
@@ -18,7 +19,7 @@ class JPAL:
         record = next(self.client)
         xml = BeautifulSoup(record, "html.parser")
         json_url = xml.metadata["directapicall"]
-        dataverse_json = requests.get(json_url).json()
+        dataverse_json = self.session.get(json_url).json()
         dataset = create_from_dataverse_json(dataverse_json)
         return dataset
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,51 +1,27 @@
-import pytest
 import requests_mock
 
 from hoard.api import Api
-from hoard.client import DataverseClient, Transport, DataverseKey
-from hoard.models import create_from_dict
+from hoard.client import DataverseClient, DataverseKey, Transport
 
 
-@pytest.fixture
-def response():
-    resp = {
-        "data": {
-            "title": "The Hoard",
-            "authorName": "Jane Doe",
-            "authorAffiliation": "Packrat University",
-            "contactName": "Jane Doe",
-            "contactEmail": "jane.doe@example.com",
-            "description": "A hoard",
-            "subjects": ["stuff", "things"],
-        }
-    }
-    return resp
-
-
-@pytest.fixture
-def dataset(response):
-    ds = create_from_dict(response["data"])
-    return ds
-
-
-def test_client_gets_dataset_by_id(response):
+def test_client_gets_dataset_by_id(dataverse_json_record):
     with requests_mock.Mocker() as m:
-        m.get("http+mock://example.com/api/v1/datasets/666", json=response)
+        m.get("http+mock://example.com/api/v1/datasets/666", json=dataverse_json_record)
         client = DataverseClient(Api("http+mock://example.com"), Transport())
         dv = client.get(id=666)
-        assert dv == response
+        assert dv == dataverse_json_record
 
 
-def test_client_gets_dataset_by_pid(response):
+def test_client_gets_dataset_by_pid(dataverse_json_record):
     with requests_mock.Mocker() as m:
         m.get(
             "http+mock://example.com/api/v1/datasets/:persistentId"
             "?persistentId=doi:foo/bar",
-            json=response,
+            json=dataverse_json_record,
         )
         client = DataverseClient(Api("http+mock://example.com"), Transport())
         dv = client.get(pid="doi:foo/bar")
-        assert dv == response
+        assert dv == dataverse_json_record
 
 
 def test_client_creates_dataset(dataset):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,17 +1,13 @@
-import json
-import pytest
-
-from hoard.models import Author, Contact, Dataset, Description
-
-
-@pytest.fixture
-def record():
-    with open("fixtures/dataset-finch1.json") as f:
-        r = json.load(f)
-        return r
+from hoard.models import (
+    Author,
+    Contact,
+    create_from_dataverse_json,
+    Dataset,
+    Description,
+)
 
 
-def test_dataset(record):
+def test_dataset(dataverse_json_record):
     author = Author(authorName="Finch, Fiona", authorAffiliation="Birds Inc.")
     contact = Contact(
         datasetContactName="Finch, Fiona", datasetContactEmail="finch@mailinator.com"
@@ -28,4 +24,9 @@ def test_dataset(record):
         subjects=["Medicine, Health and Life Sciences"],
         title="Darwin's Finches",
     )
-    assert new_record.asdict() == record
+    assert new_record.asdict() == dataverse_json_record
+
+
+def test_create_dataset_from_dataverse_json(dataverse_json_record):
+    dataset = create_from_dataverse_json(dataverse_json_record)
+    assert dataset.asdict() == dataverse_json_record

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,0 +1,19 @@
+import requests_mock
+from unittest.mock import MagicMock
+
+from hoard.source import JPAL
+
+
+def test_jpal_returns_datasets(
+    dataset, dataverse_json_record, dataverse_oai_xml_records
+):
+    oai_client = MagicMock()
+    oai_client.__next__.return_value = next(iter(dataverse_oai_xml_records))
+    with requests_mock.Mocker() as m:
+        m.get(
+            "http+mock://example.com/api/datasets/export?"
+            "exporter=dataverse_json&persistentId=12345",
+            json=dataverse_json_record,
+        )
+        jpal = JPAL(oai_client)
+        assert next(jpal) == dataset


### PR DESCRIPTION
Adds JPAL metadata source parsing.  Includes model update to create
datasets from Dataverse json metadata. Also adds conftest for sharing
fixtures across tests, and updates existing tests accordingly.