### PR TITLE
Oai client fix

### DIFF
--- a/hoard/client.py
+++ b/hoard/client.py
@@ -76,9 +76,11 @@ class OAIClient:
             header_xml = next(self.ids)
             parsed_header = ET.fromstring(header_xml.raw)
             namespace = {"oai": "http://www.openarchives.org/OAI/2.0/"}
-            id = parsed_header.find("oai:identifier", namespace)
-            if hasattr(id, "text"):
-                id = id.text
+            id_elem = parsed_header.find("oai:identifier", namespace)
+            if id_elem is None:
+                raise Exception("No OAI identifier found")
+            else:
+                id = id_elem.text
             params = {
                 "verb": "GetRecord",
                 "metadataPrefix": self.format,

--- a/hoard/client.py
+++ b/hoard/client.py
@@ -88,15 +88,13 @@ class OAIClient:
             }
             record = session.get(self.source_url, params=params).text
             parsed_record = ET.fromstring(record)
-            for elem in [
-                e
-                for e in parsed_record.iter()
-                if e.tag == f"{{{namespace['oai']}}}header"
-            ]:
-                if "status" in elem.attrib and elem.attrib["status"] == "deleted":
-                    continue
-                else:
-                    return record
+            deleted = parsed_record.find(
+                ".//oai:header[@status='deleted']", namespaces=namespace
+            )
+            if deleted:
+                continue
+            else:
+                return record
 
     def fetch_ids(self) -> Iterator:
         client = self.client

--- a/tests/data/OAI_GetRecord.xml
+++ b/tests/data/OAI_GetRecord.xml
@@ -1,1 +1,1 @@
-<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchemainstance"><GetRecord><record><header><identifier>1234</identifier></header><metadata><oai_dc:dc></oai_dc:dc></metadata></record></GetRecord></OAI-PMH>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchemainstance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"><GetRecord><record><header><identifier>1234</identifier></header><metadata><oai_dc:dc></oai_dc:dc></metadata></record></GetRecord></OAI-PMH>

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -64,4 +64,4 @@ def test_oaiclient_get(shared_datadir):
         set = "testcollection"
         records = OAIClient(source_url, format, set)
         for record in records:
-            assert record.header.identifier == "1234"
+            assert record == (shared_datadir / "OAI_GetRecord.xml").read_text()


### PR DESCRIPTION
Replacing sickle's GetRecord functionality with Elementtree for the OAIClient's `__next__` method