### PR TITLE
Ingest fixes

### DIFF
--- a/hoard/api.py
+++ b/hoard/api.py
@@ -10,7 +10,7 @@ class ApiV1:
         self.auth = auth
 
     def create_dataset(self, parent: str, dataset: dict) -> requests.Request:
-        url = f"{self.url}/{parent}/datasets"
+        url = f"{self.url}/dataverses/{parent}/datasets"
         return requests.Request("POST", url, json=dataset, auth=self.auth)
 
     def get_dataset_by_id(self, id: int) -> requests.Request:

--- a/hoard/cli.py
+++ b/hoard/cli.py
@@ -6,9 +6,7 @@ from smart_open import open  # type: ignore
 from hoard.api import Api
 from hoard.client import DataverseClient, DataverseKey, OAIClient, Transport
 from hoard.models import Dataset
-from hoard.sources.jpal import JPAL
-from hoard.sources.lincolnLab import LincolnLab
-from hoard.sources.whoas import WHOAS
+from hoard.sources import JPAL, LincolnLab, WHOAS
 
 
 @click.group()

--- a/hoard/cli.py
+++ b/hoard/cli.py
@@ -8,6 +8,7 @@ from hoard.client import DataverseClient, DataverseKey, OAIClient, Transport
 from hoard.models import Dataset
 from hoard.sources.jpal import JPAL
 from hoard.sources.lincolnLab import LincolnLab
+from hoard.sources.whoas import WHOAS
 
 
 @click.group()
@@ -16,7 +17,9 @@ def main():
 
 
 @main.command()
-@click.argument("source", type=click.Choice(["jpal", "llab"], case_sensitive=False))
+@click.argument(
+    "source", type=click.Choice(["jpal", "llab", "whoas"], case_sensitive=False)
+)
 @click.argument("source_url")
 @click.option("--key", "-k", help="RDR authentication key.")
 @click.option(
@@ -52,6 +55,9 @@ def ingest(
     elif source == "llab":
         stream = open(source_url)
         records = LincolnLab(stream)
+    elif source == "whoas":
+        client = OAIClient(source_url, "dim", "com_1912_4134")
+        records = WHOAS(client)
     for record in records:
         dv_id, p_id = rdr.create(record, parent=parent)
         if verbose:

--- a/hoard/sources/__init__.py
+++ b/hoard/sources/__init__.py
@@ -1,0 +1,6 @@
+from hoard.sources.jpal import JPAL
+from hoard.sources.lincolnLab import LincolnLab
+from hoard.sources.whoas import WHOAS
+
+
+__all__ = ["JPAL", "LincolnLab", "WHOAS"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from hoard.cli import main
 
 def test_cli_ingests(requests_mock, jpal_oai_server, jpal_dataverse_server):
     requests_mock.post(
-        "http+mock://example.com/api/v1/root/datasets",
+        "http+mock://example.com/api/v1/dataverses/root/datasets",
         json={"data": {"id": 1, "persistentId": "set1"}},
     )
     result = CliRunner().invoke(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,7 +30,7 @@ def test_client_gets_dataset_by_pid(dataverse_minimal_json_record):
 def test_client_creates_dataset(dataset):
     with requests_mock.Mocker() as m:
         m.post(
-            "http+mock://example.com/api/v1/root/datasets",
+            "http+mock://example.com/api/v1/dataverses/root/datasets",
             json={"data": {"id": 1, "persistentId": "set1"}},
         )
         client = DataverseClient(Api("http+mock://example.com/"), Transport())
@@ -43,7 +43,7 @@ def test_client_creates_dataset(dataset):
 def test_client_adds_authentication(dataset):
     with requests_mock.Mocker() as m:
         m.post(
-            "http+mock://example.com/api/v1/root/datasets",
+            "http+mock://example.com/api/v1/dataverses/root/datasets",
             json={"data": {"id": 1, "persistentId": "set1"}},
         )
         api = Api("http+mock://example.com", DataverseKey("123"))


### PR DESCRIPTION
Make a few minor fixes/additions to enable ingest to work for all current sources. Includes updating the create API endpoint to match the Dataverse URL pattern, and adding WHOAS as a source to the CLI.

Note that we should add a CLI test for WHOAS ingest (I'll create a ticket for that), but I wanted to push this code ASAP because local integration testing cannot be done without these fixes.