### PR TITLE
Add DLC to author

### DIFF
--- a/hoard/names/db.py
+++ b/hoard/names/db.py
@@ -13,7 +13,7 @@ metadata = MetaData()
 
 
 authors = Table(
-    "library_person_lookup",
+    "hr_person_employee_limited",
     metadata,
     Column("mit_id", String),
     Column("first_name", Unicode),
@@ -22,13 +22,14 @@ authors = Table(
     Column("full_name", Unicode),
     Column("krb_name", String),
     Column("email", String),
+    Column("directory_org_unit_title", String),
 )
 
 
 orcids = Table(
     "orcid_to_mitid",
     metadata,
-    Column("mit_id", String, ForeignKey("library_person_lookup.mit_id")),
+    Column("mit_id", String, ForeignKey("hr_person_employee_limited.mit_id")),
     Column("orcid", String),
 )
 

--- a/hoard/names/repository.py
+++ b/hoard/names/repository.py
@@ -20,10 +20,19 @@ class Warehouse:
             query.append(authors.c.middle_name.like(middle[0] + "%"))
         sql = (
             select(
-                [authors.c.krb_name.label("kerb"), authors.c.full_name, orcids.c.orcid]
+                [
+                    authors.c.krb_name.label("kerb"),
+                    authors.c.full_name.label("name"),
+                    orcids.c.orcid,
+                    authors.c.directory_org_unit_title.label("dlc"),
+                ]
             )
             .select_from(authors.outerjoin(orcids))
             .where(and_(*query))
+            .limit(10)
         )
         with closing(self.engine.connect()) as conn:
-            yield from conn.execute(sql)
+            yield from (
+                Author(kerb=row.kerb, name=row.name, orcid=row.orcid, dlc=row.dlc)
+                for row in conn.execute(sql)
+            )

--- a/hoard/names/types.py
+++ b/hoard/names/types.py
@@ -1,11 +1,11 @@
-from typing import Iterable, Protocol
-from typing_extensions import TypedDict
+from typing import Iterable, Optional, Protocol, TypedDict
 
 
 class Author(TypedDict):
     kerb: str
-    full_name: str
-    orcid: str
+    name: str
+    orcid: Optional[str]
+    dlc: str
 
 
 class Searchable(Protocol):

--- a/tests/data/warehouse.json
+++ b/tests/data/warehouse.json
@@ -7,7 +7,8 @@
             "last_name": "Durance",
             "full_name": "Durance, Honor E",
             "krb_name": "honor",
-            "email": "honor@example.com"
+            "email": "honor@example.com",
+            "directory_org_unit_title": "Philosophy"
         },
         {
             "mit_id": "900000001",
@@ -16,7 +17,8 @@
             "last_name": "Briggs",
             "full_name": "Briggs, Increase D",
             "krb_name": "increase",
-            "email": "increase@example.com"
+            "email": "increase@example.com",
+            "directory_org_unit_title": "Architecture"
         },
         {
             "mit_id": "900000002",
@@ -25,7 +27,8 @@
             "last_name": "Joiner",
             "full_name": "Joiner, Temperance F",
             "krb_name": "temperance",
-            "email": "temperance@example.com"
+            "email": "temperance@example.com",
+            "directory_org_unit_title": "Physics"
         },
         {
             "mit_id": "900000003",
@@ -34,7 +37,8 @@
             "last_name": "Joiner",
             "full_name": "Joiner, Silence G",
             "krb_name": "silence",
-            "email": "silence@example.com"
+            "email": "silence@example.com",
+            "directory_org_unit_title": "Math"
         }
     ],
     "orcids": [

--- a/tests/names/test_repository.py
+++ b/tests/names/test_repository.py
@@ -6,14 +6,41 @@ def test_warehouse_finds_author(warehouse_data):
     warehouse = Warehouse(engine())
 
     results = list(warehouse.find(first="Temper", middle="F", last="Joiner"))
-    assert results == [("temperance", "Joiner, Temperance F", None)]
+    assert results == [
+        {
+            "kerb": "temperance",
+            "name": "Joiner, Temperance F",
+            "orcid": None,
+            "dlc": "Physics",
+        }
+    ]
 
     results = list(warehouse.find(first="", middle="", last="Joiner"))
-    assert ("temperance", "Joiner, Temperance F", None) in results
-    assert ("silence", "Joiner, Silence G", None) in results
+    assert {
+        "kerb": "temperance",
+        "name": "Joiner, Temperance F",
+        "orcid": None,
+        "dlc": "Physics",
+    } in results
+    assert {
+        "kerb": "silence",
+        "name": "Joiner, Silence G",
+        "orcid": None,
+        "dlc": "Math",
+    } in results
 
     results = list(warehouse.find(first="I", middle="D", last="Briggs"))
-    assert ("increase", "Briggs, Increase D", "0000-0000-0001") in results
+    assert {
+        "kerb": "increase",
+        "name": "Briggs, Increase D",
+        "orcid": "0000-0000-0001",
+        "dlc": "Architecture",
+    } in results
 
     results = list(warehouse.find(last="Durance"))
-    assert ("honor", "Durance, Honor E", "0000-0000-0000") in results
+    assert {
+        "kerb": "honor",
+        "name": "Durance, Honor E",
+        "orcid": "0000-0000-0000",
+        "dlc": "Philosophy",
+    } in results


### PR DESCRIPTION
This adds the DLC to an author returned by the author service. I have
also changed it to coerce the return value into a dictionary.
Previously, it was an SQLAlchemy RowProxy which functions like a
dictionary but is not. Mypy has problems with this.