### PR TITLE
Configure logging

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,10 +20,12 @@ requests = "*"
 attrs = "*"
 bs4 = "*"
 sickle = "*"
-smart-open = {extras = ["aws"], version = "*"}
+smart-open = {extras = ["s3"], version = "*"}
 pycountry = "*"
 sqlalchemy = "*"
 cx-oracle = "*"
+structlog = "*"
+colorama = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8b802a1fe0ceb4e6bf6f38015c16eb1ca501714719487913e2bc7141b3bcd6e0"
+            "sha256": "89bfbc265cd5c57ecca2818e3716b99305a37f038b688e20f4480a8003a66c61"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,26 +32,19 @@
             ],
             "version": "==4.9.1"
         },
-        "boto": {
-            "hashes": [
-                "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8",
-                "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"
-            ],
-            "version": "==2.49.0"
-        },
         "boto3": {
             "hashes": [
-                "sha256:28bf1bce2979d4d1674d63b1b4d6ac30b6844b5d3604e69d8847b18602588861",
-                "sha256:78f3ebcdff149d5327f27a5c461a9e394306b7db9a60e8bd65c9401cc41d99d3"
+                "sha256:0c464a7de522f88b581ca0d41ffa71e9be5e17fbb0456c275421f65b7c5f6a55",
+                "sha256:0fce548e19d6db8e11fd0e2ae7809e1e3282080636b4062b2452bfa20e4f0233"
             ],
-            "version": "==1.15.0"
+            "version": "==1.15.5"
         },
         "botocore": {
             "hashes": [
-                "sha256:1dbd37af06432eda8a5736bd82f92ddd1ae8de74e4faa090bd728f8d58d24849",
-                "sha256:f3d509f06201582e60523263d52016b50415461bc6a03afb5434f477a1de3ba0"
+                "sha256:7ce7a05b98ffb3170396960273383e8aade9be6026d5a762f5f40969d5d6b761",
+                "sha256:e3bf44fba058f6df16006b94a67650418a080a525c82521abb3cb516a4cba362"
             ],
-            "version": "==1.18.0"
+            "version": "==1.18.5"
         },
         "bs4": {
             "hashes": [
@@ -81,6 +74,14 @@
             ],
             "index": "pypi",
             "version": "==7.1.2"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
+                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+            ],
+            "index": "pypi",
+            "version": "==0.4.3"
         },
         "cx-oracle": {
             "hashes": [
@@ -202,13 +203,13 @@
         },
         "smart-open": {
             "extras": [
-                "aws"
+                "s3"
             ],
             "hashes": [
-                "sha256:51b05acd85ec007e1d4dcdbf2bbf917218a45026f37d559559401114bb5e5840"
+                "sha256:3e95f4d3edc566aed46d0711c69b1a7b3d14ddf3af61cfa941e76cdb1dfe9918"
             ],
             "index": "pypi",
-            "version": "==2.1.1"
+            "version": "==2.2.0"
         },
         "soupsieve": {
             "hashes": [
@@ -256,12 +257,20 @@
             "index": "pypi",
             "version": "==1.3.19"
         },
+        "structlog": {
+            "hashes": [
+                "sha256:7a48375db6274ed1d0ae6123c486472aa1d0890b08d314d2b016f3aa7f35990b",
+                "sha256:8a672be150547a93d90a7d74229a29e765be05bd156a35cdcc527ebf68e9af92"
+            ],
+            "index": "pypi",
+            "version": "==20.1.0"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version != '3.4'",
             "version": "==1.25.10"
         }
     },
@@ -613,7 +622,7 @@
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version != '3.4'",
             "version": "==1.25.10"
         }
     }

--- a/hoard/cli.py
+++ b/hoard/cli.py
@@ -1,7 +1,10 @@
+import logging
+import sys
 from typing import Iterator, Optional
 
 import click
 from smart_open import open  # type: ignore
+import structlog  # type: ignore
 
 from hoard.api import Api
 from hoard.client import DataverseClient, DataverseKey, OAIClient, Transport
@@ -11,7 +14,23 @@ from hoard.sources import JPAL, LincolnLab, WHOAS
 
 @click.group()
 def main():
-    pass
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M.%S"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.dev.ConsoleRenderer(pad_event=0),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
 
 
 @main.command()


### PR DESCRIPTION
I'm using structlog (https://www.structlog.org) which gives us a bit
better output for less work. If you need a logger do:
```python
  logger = structlog.get_logger()
```
at module level and use just like you would a stdlib logger.

This also updates the dependency for smart_open which, for some reason,
changed the extras_require for aws to s3 when it got updated to 2.2.