### PR TITLE
Handle HTTP errors during ingest

### DIFF
--- a/hoard/cli.py
+++ b/hoard/cli.py
@@ -4,6 +4,7 @@ from typing import Iterator, Optional
 
 import click
 from smart_open import open  # type: ignore
+import requests
 import structlog  # type: ignore
 
 from hoard.api import Api
@@ -76,8 +77,14 @@ def ingest(
         client = OAIClient(source_url, "dim", "com_1912_4134")
         records = WHOAS(client)
     for record in records:
-        dv_id, p_id = rdr.create(record, parent=parent)
-        if verbose:
-            click.echo(f"Created {p_id}")
-        count += 1
+        try:
+            dv_id, p_id = rdr.create(record, parent=parent)
+            if verbose:
+                click.echo(f"Created {p_id}")
+            count += 1
+        except requests.HTTPError as e:
+            click.echo(
+                f"Unable to ingest record. HTTP error: {e}."
+                f"Dataverse response: {e.response.text}"
+            )
     click.echo(f"{count} records ingested from {source}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,10 @@ from hoard.cli import main
 def test_cli_jpal_ingests(requests_mock, jpal_oai_server, jpal_dataverse_server):
     requests_mock.post(
         "http+mock://example.com/api/v1/dataverses/root/datasets",
-        json={"data": {"id": 1, "persistentId": "set1"}},
+        [
+            {"json": {"data": {"id": 1, "persistentId": "set1"}}, "status_code": 200},
+            {"text": "Dataverse json parsing error", "status_code": 400},
+        ],
     )
     result = CliRunner().invoke(
         main,
@@ -19,7 +22,8 @@ def test_cli_jpal_ingests(requests_mock, jpal_oai_server, jpal_dataverse_server)
         ],
     )
     assert result.exit_code == 0
-    assert result.output == "2 records ingested from jpal\n"
+    assert "1 records ingested from jpal\n" in result.output
+    assert "HTTP error: 400" in result.output
 
 
 def test_cli_whoas_ingests(requests_mock, whoas_oai_server):


### PR DESCRIPTION
Catches HTTP errors during dataset ingest and prints them for review. Includes the HTTP error message and the requests response text for more detailed information on what happened in Dataverse.