### PR TITLE
series name look up

### DIFF
--- a/hoard/sources/whoas.py
+++ b/hoard/sources/whoas.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Iterator
+from urllib.parse import urlparse
 
 import pycountry  # type: ignore
 import xml.etree.ElementTree as ET
@@ -139,7 +140,8 @@ def create_from_whoas_dim_xml(data: str, client: OAIClient) -> Dataset:
                 "https://hdl.handle.net/"
             ):
                 series_args = {"seriesInformation": field.text}
-                id = f"oai:darchive.mblwhoilibrary.org:{field.text[23:]}"
+                parsed_url = urlparse(field.text)
+                id = f"oai:darchive.mblwhoilibrary.org:{parsed_url.path[1:]}"
                 series_name = client.get_record_title(id)
                 series_args["seriesName"] = series_name
                 kwargs["series"] = Series(**series_args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,12 @@ def dspace_oai_xml_records(shared_datadir):
 
 
 @pytest.fixture
+def dspace_oai_xml_series_name_record(shared_datadir):
+    record = (shared_datadir / "whoas/GetRecordSeriesName.xml").read_text()
+    return record
+
+
+@pytest.fixture
 def jpal_oai_server(requests_mock, shared_datadir, request):
     url = "http+mock://example.com/oai"
     records = {

--- a/tests/data/whoas/GetRecordSeriesName.xml
+++ b/tests/data/whoas/GetRecordSeriesName.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="static/style.xsl"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>2020-08-12T18:18:43Z</responseDate>
+  <request verb="GetRecord" identifier="oai:darchive.mblwhoilibrary.org:1912/2367" metadataPrefix="oai_dc">https://darchive.mblwhoilibrary.org/oai/request</request>
+  <GetRecord>
+    <record>
+      <header>
+        <identifier>oai:darchive.mblwhoilibrary.org:1912/6867</identifier>
+        <datestamp>2016-09-26T17:42:49Z</datestamp>
+        <setSpec>com_1912_1726</setSpec>
+        <setSpec>com_1912_1725</setSpec>
+        <setSpec>com_1912_4</setSpec>
+        <setSpec>col_1912_2364</setSpec>
+      </header>
+      <metadata>
+        <dim:dim xmlns:doc="http://www.lyncode.com/xoai" xmlns:dim="http://www.dspace.org/xmlns/dspace/dim" xsi:schemaLocation="http://www.dspace.org/xmlns/dspace/dim http://www.dspace.org/schema/dim.xsd">
+          <dim:field mdschema="dc" element="identifier" qualifier="uri">https://hdl.handle.net/1912/6867</dim:field>
+          <dim:field mdschema="dc" element="title" lang="en_US">Series Title</dim:field>
+        </dim:dim>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,14 @@ def test_cli_jpal_ingests(requests_mock, jpal_oai_server, jpal_dataverse_server)
     assert "HTTP error: 400" in result.output
 
 
-def test_cli_whoas_ingests(requests_mock, whoas_oai_server):
+def test_cli_whoas_ingests(
+    requests_mock, whoas_oai_server, dspace_oai_xml_series_name_record
+):
+    requests_mock.get(
+        "http+mock://example.com/oai?verb=GetRecord&metadataPrefix=dim"
+        "&identifier=oai%3Adarchive.mblwhoilibrary.org:1912/6867",
+        text=dspace_oai_xml_series_name_record,
+    )
     requests_mock.post(
         "http+mock://example.com/api/v1/dataverses/root/datasets",
         json={"data": {"id": 1, "persistentId": "set1"}},

--- a/tests/test_whoas.py
+++ b/tests/test_whoas.py
@@ -1,6 +1,7 @@
 import requests_mock
 from unittest.mock import MagicMock
 
+from hoard.client import OAIClient
 from hoard.models import (
     Author,
     Contact,
@@ -16,90 +17,103 @@ from hoard.models import (
 from hoard.sources.whoas import create_from_whoas_dim_xml, WHOAS
 
 
-def test_create_whoas_required_dim_xml(whoas_oai_server):
-    title = (
-        "Animals on the Move and Deep‐Sea Vents: Dataset for Spherical Display Systems"
-    )
-    authors = [
-        Author(
-            authorName="Beaulieu, Stace E.",
-            authorAffiliation="Woods Hole",
-            authorIdentifierScheme=None,
-            authorIdentifier=None,
-        ),
-        Author(
-            authorName="Brickley, Annette",
-            authorAffiliation="Woods Hole",
-            authorIdentifierScheme=None,
-            authorIdentifier=None,
-        ),
-    ]
-    contacts = [
-        Contact(
-            datasetContactName="NAME, FAKE",
-            datasetContactEmail="FAKE_EMAIL@EXAMPLE.COM",
+def test_create_whoas_dim_xml(whoas_oai_server, dspace_oai_xml_series_name_record):
+    with requests_mock.Mocker() as m:
+        m.get(
+            "http+mock://example.com/oai?verb=GetRecord&metadataPrefix=dim"
+            "&identifier=oai%3Adarchive.mblwhoilibrary.org:1912/6867",
+            text=dspace_oai_xml_series_name_record,
         )
-    ]
-    description = [
-        Description(
-            dsDescriptionValue="This educational package was developed.",
-            dsDescriptionDate=None,
-        ),
-        Description(dsDescriptionValue="Sample abstract", dsDescriptionDate=None,),
-    ]
-    distributors = [Distributor(distributorName="Esteemed Publishing Conglomerate")]
-    grantNumbers = [
-        GrantNumber(
-            grantNumberValue="Funding for this educational package.",
-            grantNumberAgency="Funding for this educational package.",
+        client = OAIClient("http+mock://example.com/oai", "dim", "Test_Collection")
+        title = (
+            "Animals on the Move and Deep‐Sea Vents: Dataset for Spherical Display "
+            "Systems"
         )
-    ]
-    keywords = [
-        Keyword(keywordValue="Migration"),
-        Keyword(keywordValue="Larval dispersal"),
-    ]
-    notesText = (
-        "This zipped file contains educational materials. "
-        "This educational package is Copyright ©2019 Woods"
-        " Hole Oceanographic Institution."
-    )
-    otherIds = [
-        OtherId(otherIdValue="https://hdl.handle.net/1912/2368", otherIdAgency=None),
-        OtherId(otherIdValue="10.26025/8ke9-av98", otherIdAgency=None),
-    ]
-    publications = [Publication(publicationCitation="Associated publication")]
-    series = Series(seriesName="https://hdl.handle.net/1912/6867")
+        authors = [
+            Author(
+                authorName="Beaulieu, Stace E.",
+                authorAffiliation="Woods Hole",
+                authorIdentifierScheme=None,
+                authorIdentifier=None,
+            ),
+            Author(
+                authorName="Brickley, Annette",
+                authorAffiliation="Woods Hole",
+                authorIdentifierScheme=None,
+                authorIdentifier=None,
+            ),
+        ]
+        contacts = [
+            Contact(
+                datasetContactName="NAME, FAKE",
+                datasetContactEmail="FAKE_EMAIL@EXAMPLE.COM",
+            )
+        ]
+        description = [
+            Description(
+                dsDescriptionValue="This educational package was developed.",
+                dsDescriptionDate=None,
+            ),
+            Description(dsDescriptionValue="Sample abstract", dsDescriptionDate=None,),
+        ]
+        distributors = [Distributor(distributorName="Esteemed Publishing Conglomerate")]
+        grantNumbers = [
+            GrantNumber(
+                grantNumberValue="Funding for this educational package.",
+                grantNumberAgency="Funding for this educational package.",
+            )
+        ]
+        keywords = [
+            Keyword(keywordValue="Migration"),
+            Keyword(keywordValue="Larval dispersal"),
+        ]
+        notesText = (
+            "This zipped file contains educational materials. "
+            "This educational package is Copyright ©2019 Woods"
+            " Hole Oceanographic Institution."
+        )
+        otherIds = [
+            OtherId(
+                otherIdValue="https://hdl.handle.net/1912/2368", otherIdAgency=None
+            ),
+            OtherId(otherIdValue="10.26025/8ke9-av98", otherIdAgency=None),
+        ]
+        publications = [Publication(publicationCitation="Associated publication")]
+        series = Series(
+            seriesName="Series Title",
+            seriesInformation="https://hdl.handle.net/1912/6867",
+        )
 
-    timePeriodsCovered = [
-        TimePeriodCovered(
-            timePeriodCoveredStart="2019-06-04", timePeriodCoveredEnd="2019-06-04",
-        )
-    ]
-    subjects = ["Earth and Environmental Sciences"]
-    dataset = create_from_whoas_dim_xml(whoas_oai_server[0])
-    assert dataset.title == title
-    assert dataset.authors == authors
-    assert dataset.contacts == contacts
-    assert dataset.description == description
-    assert dataset.subjects == subjects
+        timePeriodsCovered = [
+            TimePeriodCovered(
+                timePeriodCoveredStart="2019-06-04", timePeriodCoveredEnd="2019-06-04",
+            )
+        ]
+        subjects = ["Earth and Environmental Sciences"]
+        dataset = create_from_whoas_dim_xml(whoas_oai_server[0], client)
+        assert dataset.title == title
+        assert dataset.authors == authors
+        assert dataset.contacts == contacts
+        assert dataset.description == description
+        assert dataset.subjects == subjects
 
-    dataset = create_from_whoas_dim_xml(whoas_oai_server[1])
-    assert dataset.title == title
-    assert dataset.authors == authors
-    assert dataset.contacts == contacts
-    assert dataset.description == description
-    assert dataset.subjects == subjects
-    assert dataset.distributors == distributors
-    assert dataset.grantNumbers == grantNumbers
-    assert dataset.keywords == keywords
-    assert dataset.language == ["English"]
-    assert dataset.notesText == notesText
-    assert dataset.otherIds == otherIds
-    assert dataset.publications == publications
-    assert dataset.series == series
-    assert dataset.timePeriodsCovered == timePeriodsCovered
-    assert dataset.license == "Attribution 4.0 International"
-    assert dataset.termsOfUse == "Attribution 4.0 International"
+        dataset = create_from_whoas_dim_xml(whoas_oai_server[1], client)
+        assert dataset.title == title
+        assert dataset.authors == authors
+        assert dataset.contacts == contacts
+        assert dataset.description == description
+        assert dataset.subjects == subjects
+        assert dataset.distributors == distributors
+        assert dataset.grantNumbers == grantNumbers
+        assert dataset.keywords == keywords
+        assert dataset.language == ["English"]
+        assert dataset.notesText == notesText
+        assert dataset.otherIds == otherIds
+        assert dataset.publications == publications
+        assert dataset.series == series
+        assert dataset.timePeriodsCovered == timePeriodsCovered
+        assert dataset.license == "Attribution 4.0 International"
+        assert dataset.termsOfUse == "Attribution 4.0 International"
 
 
 def test_whoas_returns_datasets(dspace_oai_xml_records):


### PR DESCRIPTION
Addresses [RDRP-342](https://mitlibraries.atlassian.net/browse/RDRP-342):

- Adds method to `OAIClient` class to look up a title from a handle in the metadata and refactors the other `OAIClient` methods to avoid duplicate code. 
- Updates `create_from_whoas_dim_xml` function to accept a client as an argument in order to use the new lookup method
- Adds a testing fixture for a record with as series name but I'm not integrating it into the `whoas_oai_server` fixture because the linked record may not be a part of the set that is being ingested. Let me know if my logic is flawed there
- Updates corresponding tests in `test_cli.py` and `test_whoas.py`