### PR TITLE
Add author lookup command to CLI

### DIFF
--- a/hoard/names/__init__.py
+++ b/hoard/names/__init__.py
@@ -1,0 +1,6 @@
+from .db import engine
+from .repository import Warehouse
+from .service import AuthorService
+
+
+__all__ = ["engine", "Warehouse", "AuthorService"]

--- a/hoard/names/db.py
+++ b/hoard/names/db.py
@@ -20,7 +20,7 @@ authors = Table(
     Column("middle_name", Unicode),
     Column("last_name", Unicode),
     Column("full_name", Unicode),
-    Column("krb_name", String),
+    Column("krb_name_uppercase", String),
     Column("email", String),
     Column("directory_org_unit_title", String),
 )

--- a/hoard/names/repository.py
+++ b/hoard/names/repository.py
@@ -21,7 +21,7 @@ class Warehouse:
         sql = (
             select(
                 [
-                    authors.c.krb_name.label("kerb"),
+                    authors.c.krb_name_uppercase.label("kerb"),
                     authors.c.full_name.label("name"),
                     orcids.c.orcid,
                     authors.c.directory_org_unit_title.label("dlc"),

--- a/hoard/names/service.py
+++ b/hoard/names/service.py
@@ -15,10 +15,17 @@ class AuthorService:
 def parse(name: str) -> Tuple[str, str, str]:
     """Parse a name into constituent parts.
 
+    This assumes the name is of the form:
+
+        last, first middle
+
+    If there is no comma, it will treat the entire string as the last name.
     The returned tuple is ordered like: (last, first, middle).
     """
-    parts = name.split()
-    last = parts.pop()
+    last, *rest = name.split(",")
+    if not rest:
+        return last, "", ""
+    parts = rest[0].split()
     parts.reverse()
     try:
         first = parts.pop()

--- a/tests/data/warehouse.json
+++ b/tests/data/warehouse.json
@@ -6,7 +6,7 @@
             "middle_name": "E",
             "last_name": "Durance",
             "full_name": "Durance, Honor E",
-            "krb_name": "honor",
+            "krb_name_uppercase": "honor",
             "email": "honor@example.com",
             "directory_org_unit_title": "Philosophy"
         },
@@ -16,7 +16,7 @@
             "middle_name": "D",
             "last_name": "Briggs",
             "full_name": "Briggs, Increase D",
-            "krb_name": "increase",
+            "krb_name_uppercase": "increase",
             "email": "increase@example.com",
             "directory_org_unit_title": "Architecture"
         },
@@ -26,7 +26,7 @@
             "middle_name": "F",
             "last_name": "Joiner",
             "full_name": "Joiner, Temperance F",
-            "krb_name": "temperance",
+            "krb_name_uppercase": "temperance",
             "email": "temperance@example.com",
             "directory_org_unit_title": "Physics"
         },
@@ -36,7 +36,7 @@
             "middle_name": "G",
             "last_name": "Joiner",
             "full_name": "Joiner, Silence G",
-            "krb_name": "silence",
+            "krb_name_uppercase": "silence",
             "email": "silence@example.com",
             "directory_org_unit_title": "Math"
         }

--- a/tests/names/test_author_service.py
+++ b/tests/names/test_author_service.py
@@ -4,9 +4,10 @@ from hoard.names.service import AuthorService, parse
 
 
 def test_parse_splits_words():
-    assert parse("Foo Bar Baz Gaz") == ("Gaz", "Foo", "Bar")
-    assert parse("Foo Bar Baz") == ("Baz", "Foo", "Bar")
-    assert parse("Foo Bar") == ("Bar", "Foo", "")
+    assert parse("Foo Bar, Baz Gaz") == ("Foo Bar", "Baz", "Gaz")
+    assert parse("Foo, Bar Baz") == ("Foo", "Bar", "Baz")
+    assert parse("Foo Bar") == ("Foo Bar", "", "")
+    assert parse("Foo") == ("Foo", "", "")
 
 
 def test_author_service_produces_list_of_names():


### PR DESCRIPTION
This adds an `author` command to the CLI which can be used to lookup one
or more authors in the data warehouse. The intent is primarily for this
to be used to check how well our name parsing is working and to see what
kind of data we are getting back from the warehouse.

The command will accept any number of names as arguments, but remember
you'll need to quote them:
```
  hoard author "Foo, Bar" "Foo, Baz"
```

It will also read from stdin:
```
  hoard author < author_list.txt
```