### PR TITLE
Add S3 logging for name lookup

### DIFF
--- a/hoard/cli.py
+++ b/hoard/cli.py
@@ -11,6 +11,7 @@ from hoard.api import Api
 from hoard.client import DataverseClient, DataverseKey, OAIClient, Transport
 from hoard.models import Dataset
 from hoard.names import AuthorService, engine, Warehouse
+from hoard.names.logging import s3_log
 from hoard.sources import JPAL, LincolnLab, WHOAS
 
 
@@ -50,13 +51,19 @@ def main():
     default="http://localhost",
     help="URL for RDR. Records will be ingested into this system.",
 )
+@click.option(
+    "--name-log",
+    help="Path to file for name lookup log. Use s3://bucket/key for S3 logging.",
+)
 @click.option("--verbose", "-v", is_flag=True)
+@s3_log
 def ingest(
     source: str,
     source_url: str,
     key: Optional[str],
     url: str,
     parent: str,
+    name_log: str,
     verbose: bool,
 ) -> None:
     """Ingest a source into RDR.

--- a/hoard/names/logging.py
+++ b/hoard/names/logging.py
@@ -1,0 +1,40 @@
+import functools
+import io
+import logging
+
+import click
+from smart_open import open  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+
+
+def s3_log(f):
+    @functools.wraps(f)
+    @click.pass_context
+    def wrapped(ctx, *args, **kwargs):
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        stream = io.StringIO()
+        hdlr = logging.StreamHandler(stream)
+        hdlr.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(hdlr)
+        try:
+            res = ctx.invoke(f, *args, **kwargs)
+        finally:
+            if (filename := ctx.params.get("name_log")) :
+                with open(filename, "w") as fp:
+                    fp.write(stream.getvalue())
+        return res
+
+    return wrapped
+
+
+def log(f):
+    @functools.wraps(f)
+    def wrapped(*args, **kwargs):
+        for x in f(*args, **kwargs):
+            logger.info(x)
+            yield x
+
+    return wrapped

--- a/hoard/names/service.py
+++ b/hoard/names/service.py
@@ -1,5 +1,6 @@
 from typing import Iterable, Tuple
 
+from hoard.names.logging import log
 from hoard.names.types import Author, Searchable
 
 
@@ -7,6 +8,7 @@ class AuthorService:
     def __init__(self, repository: Searchable) -> None:
         self.repository = repository
 
+    @log
     def find(self, name: str) -> Iterable[Tuple[str, Author]]:
         for result in self.repository.find(*parse(name)):
             yield (name, result)


### PR DESCRIPTION
This configures logging to record the result of author name lookups in
S3. In fact, it will write to any file, including locally. A new option
has been added to the main ingest command called `--name-log`. To write
to an S3 file use a file path like s3://bucket/key.

The logging functionality is all applied through two decorators. As this
feature, theoretically, is temporary it should be easy to remove it when
needed.

You may note that I am not using structlog for this. structlog does not
support different formatting for different loggers (as far as I can
tell). We'll almost certainly want to have more control over formatting
so I have fallen back to stdlib logging for this. I have also disabled
propagation to keep the two logging strategies separate.

Internally, the logs are written to an in-memory buffer until the
command is done and then written to whatever file was specified.