### PR TITLE
Add mypy stub for smart_open

### DIFF
--- a/hoard/cli.py
+++ b/hoard/cli.py
@@ -3,7 +3,7 @@ import sys
 from typing import Iterator, Optional
 
 import click
-from smart_open import open  # type: ignore
+from smart_open import open
 import requests
 import structlog  # type: ignore
 

--- a/hoard/names/logging.py
+++ b/hoard/names/logging.py
@@ -1,15 +1,19 @@
 import functools
 import io
 import logging
+from typing import Any, Callable, cast, TypeVar
 
 import click
-from smart_open import open  # type: ignore
+from smart_open import open
 
 
 logger = logging.getLogger(__name__)
 
 
-def s3_log(f):
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def s3_log(f: F) -> F:
     @functools.wraps(f)
     @click.pass_context
     def wrapped(ctx, *args, **kwargs):
@@ -27,14 +31,14 @@ def s3_log(f):
                     fp.write(stream.getvalue())
         return res
 
-    return wrapped
+    return cast(F, wrapped)
 
 
-def log(f):
+def log(f: F) -> F:
     @functools.wraps(f)
     def wrapped(*args, **kwargs):
         for x in f(*args, **kwargs):
             logger.info(x)
             yield x
 
-    return wrapped
+    return cast(F, wrapped)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+mypy_path = stubs

--- a/stubs/smart_open.pyi
+++ b/stubs/smart_open.pyi
@@ -1,0 +1,4 @@
+from typing import TextIO
+
+
+def open(uri: str, mode: str = "r") -> TextIO: ...


### PR DESCRIPTION
This adds a typed stub for smart_open. It was mostly done just to see
how this would work. Since only one function is used from this module it
was easy to add just enough type constraints to turn on type checking
for it.

I also added a couple type constraints on the two logging decorators.