### PR TITLE
Add fallback for missing description

### DIFF
--- a/hoard/sources/whoas.py
+++ b/hoard/sources/whoas.py
@@ -184,6 +184,8 @@ def create_from_whoas_dim_xml(data: str, client: OAIClient) -> Dataset:
             kwargs["termsOfUse"] = field.text
 
     kwargs["subjects"] = ["Earth and Environmental Sciences"]
+    if "description" not in kwargs:
+        kwargs["description"] = kwargs["title"]
     if notesText != "":
         kwargs["notesText"] = notesText
     return Dataset(**kwargs)

--- a/hoard/sources/whoas.py
+++ b/hoard/sources/whoas.py
@@ -185,7 +185,7 @@ def create_from_whoas_dim_xml(data: str, client: OAIClient) -> Dataset:
 
     kwargs["subjects"] = ["Earth and Environmental Sciences"]
     if "description" not in kwargs:
-        kwargs["description"] = kwargs["title"]
+        kwargs["description"] = [Description(dsDescriptionValue=kwargs["title"])]
     if notesText != "":
         kwargs["notesText"] = notesText
     return Dataset(**kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,9 @@ def whoas_oai_server(requests_mock, shared_datadir, request):
         "oai:darchive.mblwhoilibrary.org:1912/2372": (
             shared_datadir / "whoas/GetRecord_06.xml"
         ).read_text(),
+        "oai:darchive.mblwhoilibrary.org:1912/2373": (
+            shared_datadir / "whoas/GetRecord_07.xml"
+        ).read_text(),
     }
     requests_mock.get(
         f"{url}?verb=ListIdentifiers",
@@ -123,6 +126,7 @@ def whoas_oai_server(requests_mock, shared_datadir, request):
         records["oai:darchive.mblwhoilibrary.org:1912/2370"],
         records["oai:darchive.mblwhoilibrary.org:1912/2371"],
         records["oai:darchive.mblwhoilibrary.org:1912/2372"],
+        records["oai:darchive.mblwhoilibrary.org:1912/2373"],
     ]
 
 

--- a/tests/data/whoas/GetRecord_07.xml
+++ b/tests/data/whoas/GetRecord_07.xml
@@ -2,11 +2,11 @@
 <?xml-stylesheet type="text/xsl" href="static/style.xsl"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>2020-08-12T18:18:43Z</responseDate>
-  <request verb="GetRecord" identifier="oai:darchive.mblwhoilibrary.org:1912/2371" metadataPrefix="oai_dc">https://darchive.mblwhoilibrary.org/oai/request</request>
+  <request verb="GetRecord" identifier="oai:darchive.mblwhoilibrary.org:1912/2368" metadataPrefix="oai_dc">https://darchive.mblwhoilibrary.org/oai/request</request>
   <GetRecord>
     <record>
       <header>
-        <identifier>oai:darchive.mblwhoilibrary.org:1912/2371</identifier>
+        <identifier>oai:darchive.mblwhoilibrary.org:1912/2373</identifier>
         <datestamp>2016-09-26T17:42:49Z</datestamp>
         <setSpec>com_1912_1726</setSpec>
         <setSpec>com_1912_1725</setSpec>
@@ -21,7 +21,12 @@
         <dim:field mdschema="dc" element="date" qualifier="accessioned">2019-06-07T17:41:39Z</dim:field>
         <dim:field mdschema="dc" element="date" qualifier="available">2019-06-07T17:41:39Z</dim:field>
         <dim:field mdschema="dc" element="date" qualifier="issued">2019-06-04</dim:field>
-        <dim:field mdschema="dc" element="identifier" qualifier="uri">https://hdl.handle.net/1912/2371</dim:field>
+        <dim:field mdschema="dc" element="identifier" qualifier="uri">https://hdl.handle.net/1912/2373</dim:field>
+        <dim:field mdschema="dc" element="identifier" qualifier="doi">10.26025/8ke9-av98</dim:field>
+        <dim:field mdschema="dc" element="description" lang="en_US">This zipped file contains educational materials.</dim:field>
+        <dim:field mdschema="dc" element="description">This educational package is Copyright ©2019 Woods Hole Oceanographic Institution.</dim:field>
+        <dim:field mdschema="dc" element="description" qualifier="abstract" lang="en_US">This educational package was developed.</dim:field>]
+        <dim:field mdschema="dc" element="description" qualifier="abstract" lang="en">Sample abstract</dim:field>
         <dim:field mdschema="dc" element="description" qualifier="provenance" lang="en">Approved for entry into archive by Deborah Roth (droth@whoi.edu) on 2019-06-07T17:41:39Z (GMT) No. of bitstreams: 1
         animals-on-the-move_ver1_vents_ver2.zip: 820943968 bytes, checksum: 0ba7e089cb52f2ad7c30f16f58020082 (MD5)</dim:field>
         <dim:field mdschema="dc" element="description" qualifier="provenance" lang="en">Made available in DSpace on 2019-06-07T17:41:39Z (GMT). No. of bitstreams: 1
@@ -37,7 +42,6 @@
         <dim:field mdschema="dc" element="rights" qualifier="uri">http://creativecommons.org/licenses/by/4.0/</dim:field>
         <dim:field mdschema="dc" element="subject" lang="en_US">Migration</dim:field>
         <dim:field mdschema="dc" element="subject" lang="en_US">Larval dispersal</dim:field>
-        <dim:field mdschema="dc" element="title" lang="en_US">Animals on the Move and Deep‐Sea Vents: Dataset for Spherical Display Systems</dim:field>
         <dim:field mdschema="dc" element="type" lang="en_US">Dataset</dim:field>
         </dim:dim>
       </metadata>

--- a/tests/test_whoas.py
+++ b/tests/test_whoas.py
@@ -133,7 +133,7 @@ def test_create_whoas_dim_xml(whoas_oai_server, dspace_oai_xml_series_name_recor
         assert dataset.title == title
         assert dataset.authors == authors
         assert dataset.contacts == contacts
-        assert dataset.description == title
+        assert dataset.description == [Description(dsDescriptionValue=title)]
         assert dataset.subjects == subjects
         assert dataset.distributors == distributors
         assert dataset.grantNumbers == grantNumbers

--- a/tests/test_whoas.py
+++ b/tests/test_whoas.py
@@ -77,6 +77,9 @@ def test_create_whoas_dim_xml(whoas_oai_server, dspace_oai_xml_series_name_recor
             OtherId(otherIdValue="10.26025/8ke9-av98", otherIdAgency=None),
         ]
         otherIds_2 = [
+            OtherId(otherIdValue="https://hdl.handle.net/1912/2371", otherIdAgency=None)
+        ]
+        otherIds_3 = [
             OtherId(otherIdValue="https://hdl.handle.net/1912/2372", otherIdAgency=None)
         ]
         publications = [Publication(publicationCitation="Associated publication")]
@@ -84,13 +87,11 @@ def test_create_whoas_dim_xml(whoas_oai_server, dspace_oai_xml_series_name_recor
             seriesName="Series Title",
             seriesInformation="https://hdl.handle.net/1912/6867",
         )
-
         timePeriodsCovered = [
             TimePeriodCovered(
                 timePeriodCoveredStart="2019-06-04", timePeriodCoveredEnd="2019-06-04",
             )
         ]
-
         partial_timePeriodsCovered = [
             TimePeriodCovered(timePeriodCoveredStart="2019-06-04")
         ]
@@ -125,6 +126,26 @@ def test_create_whoas_dim_xml(whoas_oai_server, dspace_oai_xml_series_name_recor
         assert dataset.license == "Attribution 4.0 International"
         assert dataset.termsOfUse == "Attribution 4.0 International"
 
+        # record with no description
+        dataset = create_from_whoas_dim_xml(whoas_oai_server[4], client)
+        for _k, v in dataset.__dict__.items():
+            assert v != []
+        assert dataset.title == title
+        assert dataset.authors == authors
+        assert dataset.contacts == contacts
+        assert dataset.description == title
+        assert dataset.subjects == subjects
+        assert dataset.distributors == distributors
+        assert dataset.grantNumbers == grantNumbers
+        assert dataset.keywords == keywords
+        assert dataset.language == ["English"]
+        assert dataset.otherIds == otherIds_2
+        assert dataset.publications == publications
+        assert dataset.series == series
+        assert dataset.timePeriodsCovered == timePeriodsCovered
+        assert dataset.license == "Attribution 4.0 International"
+        assert dataset.termsOfUse == "Attribution 4.0 International"
+
         # record with invalid date
         dataset = create_from_whoas_dim_xml(whoas_oai_server[5], client)
         for _k, v in dataset.__dict__.items():
@@ -139,7 +160,7 @@ def test_create_whoas_dim_xml(whoas_oai_server, dspace_oai_xml_series_name_recor
         assert dataset.keywords == keywords
         assert dataset.language == ["English"]
         assert dataset.notesText == notesText
-        assert dataset.otherIds == otherIds_2
+        assert dataset.otherIds == otherIds_3
         assert dataset.publications == publications
         assert dataset.series == series
         assert dataset.timePeriodsCovered == partial_timePeriodsCovered


### PR DESCRIPTION
Inserts the title as a `Description` should a WHOAS record be missing a `dc.description.abstract` property. I shifted the test fixtures since I had previously used a record without `dc.description.abstract` to ensure that record would be skipped. I have substituted a new sample record without a title to test that functionality.