### PR TITLE
Switch DLC field in author service

### DIFF
--- a/hoard/cli.py
+++ b/hoard/cli.py
@@ -107,7 +107,9 @@ def pipe(ctx, param, value):
 
 @main.command()
 @click.argument("authors", nargs=-1, callback=pipe)
-@click.option("--database", help="SQLAlchemy DB connection string")
+@click.option(
+    "--database", envvar="HOARD_DB_URI", help="SQLAlchemy DB connection string"
+)
 def author(authors, database) -> None:
     """Search for one or more authors.
 

--- a/hoard/names/db.py
+++ b/hoard/names/db.py
@@ -22,7 +22,7 @@ authors = Table(
     Column("full_name", Unicode),
     Column("krb_name_uppercase", String),
     Column("email", String),
-    Column("directory_org_unit_title", String),
+    Column("hr_org_unit_title", String),
 )
 
 

--- a/hoard/names/repository.py
+++ b/hoard/names/repository.py
@@ -24,7 +24,7 @@ class Warehouse:
                     authors.c.krb_name_uppercase.label("kerb"),
                     authors.c.full_name.label("name"),
                     orcids.c.orcid,
-                    authors.c.directory_org_unit_title.label("dlc"),
+                    authors.c.hr_org_unit_title.label("dlc"),
                 ]
             )
             .select_from(authors.outerjoin(orcids))

--- a/tests/data/warehouse.json
+++ b/tests/data/warehouse.json
@@ -8,7 +8,7 @@
             "full_name": "Durance, Honor E",
             "krb_name_uppercase": "honor",
             "email": "honor@example.com",
-            "directory_org_unit_title": "Philosophy"
+            "hr_org_unit_title": "Philosophy"
         },
         {
             "mit_id": "900000001",
@@ -18,7 +18,7 @@
             "full_name": "Briggs, Increase D",
             "krb_name_uppercase": "increase",
             "email": "increase@example.com",
-            "directory_org_unit_title": "Architecture"
+            "hr_org_unit_title": "Architecture"
         },
         {
             "mit_id": "900000002",
@@ -28,7 +28,7 @@
             "full_name": "Joiner, Temperance F",
             "krb_name_uppercase": "temperance",
             "email": "temperance@example.com",
-            "directory_org_unit_title": "Physics"
+            "hr_org_unit_title": "Physics"
         },
         {
             "mit_id": "900000003",
@@ -38,7 +38,7 @@
             "full_name": "Joiner, Silence G",
             "krb_name_uppercase": "silence",
             "email": "silence@example.com",
-            "directory_org_unit_title": "Math"
+            "hr_org_unit_title": "Math"
         }
     ],
     "orcids": [


### PR DESCRIPTION
Based on the response from IS&T, I have switched to using
HR_ORG_UNIT_TITLE as the DLC field.