### PR TITLE
Add envvar to RDR authentication option

### DIFF
--- a/hoard/cli.py
+++ b/hoard/cli.py
@@ -41,7 +41,7 @@ def main():
     "source", type=click.Choice(["jpal", "llab", "whoas"], case_sensitive=False)
 )
 @click.argument("source_url")
-@click.option("--key", "-k", help="RDR authentication key.")
+@click.option("--key", "-k", envvar="HOARD_RDR_KEY", help="RDR authentication key.")
 @click.option(
     "--parent", "-p", default="root", help="Parent dataverse to ingest items into."
 )


### PR DESCRIPTION
Given that the authentication key for RDR is something we'd like to keep
secret, I'm adding the ability to set this option through an environment
variable.