### PR TITLE
from_date

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,6 +26,7 @@ sqlalchemy = "*"
 cx-oracle = "*"
 structlog = "*"
 colorama = "*"
+lxml = "*"
 
 [requires]
 python_version = "3.8"

--- a/hoard/cli.py
+++ b/hoard/cli.py
@@ -56,6 +56,9 @@ def main():
     help="Path to file for name lookup log. Use s3://bucket/key for S3 logging.",
 )
 @click.option("--verbose", "-v", is_flag=True)
+@click.option(
+    "--from_date", "-f", help="The record date after which records should be ingested"
+)
 @s3_log
 def ingest(
     source: str,
@@ -65,6 +68,7 @@ def ingest(
     parent: str,
     name_log: str,
     verbose: bool,
+    from_date: str,
 ) -> None:
     """Ingest a source into RDR.
 
@@ -76,13 +80,15 @@ def ingest(
     rdr = DataverseClient(Api(url, DataverseKey(key)), Transport())
     records: Iterator[Dataset]
     if source == "jpal":
-        client = OAIClient(source_url, "dataverse_json", "Jameel_Poverty_Action_Lab")
+        client = OAIClient(
+            source_url, "dataverse_json", "Jameel_Poverty_Action_Lab", from_date
+        )
         records = JPAL(client)
     elif source == "llab":
         stream = open(source_url)
         records = LincolnLab(stream)
     elif source == "whoas":
-        client = OAIClient(source_url, "dim", "com_1912_4134")
+        client = OAIClient(source_url, "dim", "com_1912_4134", from_date)
         records = WHOAS(client)
     for record in records:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,10 @@ def whoas_oai_server(requests_mock, shared_datadir, request):
         f"{url}?verb=ListIdentifiers",
         text=(shared_datadir / "whoas/ListRecords.xml").read_text(),
     )
+    requests_mock.get(
+        f"{url}?verb=ListIdentifiers&from=2016-09-25",
+        text=(shared_datadir / "whoas/ListRecordsDateTest.xml").read_text(),
+    )
     for k, v in records.items():
         requests_mock.get(f"{url}?identifier={k}", text=v)
     return [

--- a/tests/data/whoas/GetRecord_07.xml
+++ b/tests/data/whoas/GetRecord_07.xml
@@ -2,12 +2,12 @@
 <?xml-stylesheet type="text/xsl" href="static/style.xsl"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>2020-08-12T18:18:43Z</responseDate>
-  <request verb="GetRecord" identifier="oai:darchive.mblwhoilibrary.org:1912/2368" metadataPrefix="oai_dc">https://darchive.mblwhoilibrary.org/oai/request</request>
+  <request verb="GetRecord" identifier="oai:darchive.mblwhoilibrary.org:1912/2373" metadataPrefix="oai_dc">https://darchive.mblwhoilibrary.org/oai/request</request>
   <GetRecord>
     <record>
       <header>
         <identifier>oai:darchive.mblwhoilibrary.org:1912/2373</identifier>
-        <datestamp>2016-09-26T17:42:49Z</datestamp>
+        <datestamp>2015-09-20T17:42:49Z</datestamp>
         <setSpec>com_1912_1726</setSpec>
         <setSpec>com_1912_1725</setSpec>
         <setSpec>com_1912_4</setSpec>
@@ -18,9 +18,9 @@
         <dim:field mdschema="dc" element="contributor" qualifier="author" authority="3fe71a0a-2805-4c59-829e-cb9664896bfa" confidence="600">Beaulieu, Stace E.</dim:field>
         <dim:field mdschema="dc" element="contributor" qualifier="author" authority="3fe71a0a-2805-4c59-829e-cb9664896bfa" confidence="600">Brickley, Annette</dim:field>
         <dim:field mdschema="dc" element="coverage" qualifier="temporal">2019-06-04 - 2019-06-04(UTC)</dim:field>
-        <dim:field mdschema="dc" element="date" qualifier="accessioned">2019-06-07T17:41:39Z</dim:field>
-        <dim:field mdschema="dc" element="date" qualifier="available">2019-06-07T17:41:39Z</dim:field>
-        <dim:field mdschema="dc" element="date" qualifier="issued">2019-06-04</dim:field>
+        <dim:field mdschema="dc" element="date" qualifier="accessioned">2015-09-20T17:42:49Z</dim:field>
+        <dim:field mdschema="dc" element="date" qualifier="available">2015-09-20T17:42:49Z</dim:field>
+        <dim:field mdschema="dc" element="date" qualifier="issued">2015-09-20</dim:field>
         <dim:field mdschema="dc" element="identifier" qualifier="uri">https://hdl.handle.net/1912/2373</dim:field>
         <dim:field mdschema="dc" element="identifier" qualifier="doi">10.26025/8ke9-av98</dim:field>
         <dim:field mdschema="dc" element="description" lang="en_US">This zipped file contains educational materials.</dim:field>
@@ -42,6 +42,7 @@
         <dim:field mdschema="dc" element="rights" qualifier="uri">http://creativecommons.org/licenses/by/4.0/</dim:field>
         <dim:field mdschema="dc" element="subject" lang="en_US">Migration</dim:field>
         <dim:field mdschema="dc" element="subject" lang="en_US">Larval dispersal</dim:field>
+        <dim:field mdschema="dc" element="title" lang="en_US">Animals on the Move and Deep‐Sea Vents: Dataset for Spherical Display Systems</dim:field>
         <dim:field mdschema="dc" element="type" lang="en_US">Dataset</dim:field>
         </dim:dim>
       </metadata>

--- a/tests/data/whoas/ListRecordsDateTest.xml
+++ b/tests/data/whoas/ListRecordsDateTest.xml
@@ -52,13 +52,5 @@
       <setSpec>com_1912_4</setSpec>
       <setSpec>col_1912_2364</setSpec>
     </header>
-    <header>
-      <identifier>oai:darchive.mblwhoilibrary.org:1912/2373</identifier>
-      <datestamp>2015-09-20T17:42:49Z</datestamp>
-      <setSpec>com_1912_1726</setSpec>
-      <setSpec>com_1912_1725</setSpec>
-      <setSpec>com_1912_4</setSpec>
-      <setSpec>col_1912_2364</setSpec>
-    </header>
   </ListIdentifiers>
 </OAI-PMH>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,7 +38,8 @@ def test_cli_whoas_ingests(
         "http+mock://example.com/api/v1/dataverses/root/datasets",
         json={"data": {"id": 1, "persistentId": "set1"}},
     )
-    result = CliRunner().invoke(
+    # without from_date
+    result_1 = CliRunner().invoke(
         main,
         [
             "ingest",
@@ -48,5 +49,21 @@ def test_cli_whoas_ingests(
             "http+mock://example.com",
         ],
     )
-    assert result.exit_code == 0
-    assert result.output == "2 records ingested from whoas\n"
+    assert result_1.exit_code == 0
+    assert result_1.output == "5 records ingested from whoas\n"
+
+    # with from_date
+    result_2 = CliRunner().invoke(
+        main,
+        [
+            "ingest",
+            "whoas",
+            "http+mock://example.com/oai",
+            "--url",
+            "http+mock://example.com",
+            "--from_date",
+            "2016-09-25",
+        ],
+    )
+    assert result_2.exit_code == 0
+    assert result_2.output == "4 records ingested from whoas\n"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,3 +57,16 @@ def test_oaiclient_iterates_over_records(jpal_oai_server):
         "http+mock://example.com/oai", "dataverse_json", "Jameel_Poverty_Action_Lab"
     )
     assert list(records) == jpal_oai_server
+
+
+def test_oaiclient_skips_records_after_from_date(whoas_oai_server):
+    records = OAIClient(
+        "http+mock://example.com/oai", "dim", "com_1912_1726", "2016-09-25"
+    )
+    assert list(records) == [
+        whoas_oai_server[0],
+        whoas_oai_server[1],
+        whoas_oai_server[3],
+        whoas_oai_server[4],
+        whoas_oai_server[5],
+    ]


### PR DESCRIPTION
Adds `from_date` to CLI and `OAIClient` and validation that ignores any invalid values and logs an error. Adds to WHOAS CLI test to verify that it functions with or without a `from_date`. Also adds an `OAIClient` test to verify that the client behaves differently with a `from_date`. Let me if there's a better way to test these, this was the best approach I thought of without a full mock OAI-PMH service